### PR TITLE
Add link to onboarding documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ All the things you need to know about being a developer at Clever.
 * [Testing](./testing.md)
 * [Logging](./logging.md)
 * [Documentation](./documentation.md)
+
+Onboarding documents:
+* [Engineering Onboarding](https://clever.atlassian.net/wiki/display/ENG/Onboarding)
+* [Tutorial Part 1](https://github.com/Clever/onboarding/blob/master/getting-started/Tutorial-Part-1.md)


### PR DESCRIPTION
I use the onboarding documents as reference for running docker containers. So will be useful to link to them from here.