### PR TITLE
Add bug bounty policy

### DIFF
--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -1,0 +1,32 @@
+Clever is committed to working with security experts across the world to stay up to date with the latest security techniques. If you have discovered a security issue that you believe we should know about, we'd welcome working with you. You can read about our security and privacy efforts on our [security page](https://clever.com/security)
+
+**Coordinated disclosure rules**
+
+* Please let us know as soon as possible upon discovery of a potential security issue, and we’ll make every effort to quickly correct the issue.
+* Provide us a reasonable amount of time to fix the issue before publishing it elsewhere.
+* Making a good faith effort to not leak, manipulate, or destroy any user data. Please only test against accounts you own yourself or with explicit permission of the account holder.
+* Please refrain from automated/scripted account creation.
+
+**Bounty eligibility**
+
+Clever reserves the right to decide if the minimum severity threshold is met and whether it was previously reported. To qualify for a reward under this program, you should:
+
+* Be the first to report a specific vulnerability.
+* Send a clear textual description of the report along with steps to reproduce the vulnerability. Include attachments such as screenshots or proof of concept code as necessary.
+* Disclose the vulnerability report directly and exclusively to us. Public disclosure or disclosure to other third parties -- including vulnerability brokers -- before we addressed your report will forfeit the reward.
+
+In general, the following would not meet the threshold for severity:
+* Vulnerabilities on sites hosted by third-parties unless they lead to a vulnerability on the main website
+* Denial of service
+* Spamming
+* Email server configuration (SPF, DKIM, and DMARC)
+* Name server configuration (DNSSec)
+* Self-XSS (an XSS that requires the user to enter a payload)
+
+Thank you for helping keep Clever safe!
+
+**Thanks**
+
+We believe in recognizing the work of others.
+
+If your work helps us improve the security of our service. we'd be happy to [acknowledge your contribution](/Clever/thanks) and ensure you are fairly rewarded for your discovery.


### PR DESCRIPTION
This is the bug bounty policy from our [HackerOne page](https://hackerone.com/clever?view_policy=true).

I'd like to host this on Github for a few reasons:

1) It's easier to track changes.
2) It's in markdown format, so preserving format is easier than in Confluence or Google docs.
3) We may get some interesting external pull requests.

This will be followed up by a few PRs updating the policy. Stay tuned!