### PR TITLE
Add bump helper to thrift.mk

### DIFF
--- a/make/README.md
+++ b/make/README.md
@@ -41,3 +41,4 @@ See the [gearcmd Makefile](https://github.com/Clever/gearcmd/blob/master/Makefil
   - node
   - python
 - verification of up-to-date client code
+- bump minor/major/patch versions

--- a/make/thrift.mk
+++ b/make/thrift.mk
@@ -33,3 +33,16 @@ $(if \
 	@echo thrift client code must match thrift definition && exit 1,
 	@echo thrift client code up to date)
 endef
+
+define thrift-bump-version
+  (cd ./gen-nodejs; npm version $(1) | cut -c2- > ../VERSION)
+endef
+
+define thrift-versioning
+thrift-bump-patch:
+	$(call thrift-bump-version, patch)
+thrift-bump-minor:
+	$(call thrift-bump-version, minor)
+thrift-bump-major:
+	$(call thrift-bump-version, major)
+endef


### PR DESCRIPTION
Issue: thrift projects typically contain version number in package.json as well as VERSION file. Bumping the version is often missed as the operation is not streamlined.

Solution: Add an additional helper in the thrift.mk file that add a command `make thrift-bump-patch`. Where patch can be minor/major/patch. The command increments the relevant version in both package.json and VERSION files.