### PR TITLE
Add a node.mk makefile with a version check function

### DIFF
--- a/make/README.md
+++ b/make/README.md
@@ -33,6 +33,23 @@ See the [gearcmd Makefile](https://github.com/Clever/gearcmd/blob/master/Makefil
   - go vet
   - go test
 
+## Node
+
+- node version check
+
+Example Makefile using `node.mk`
+
+```make
+include node.mk
+.DEFAULT_GOAL := test
+
+NODE_VERSION := v6
+
+$(eval $(call node-version-check,$(NODE_VERSION)))
+
+run:
+  NODE_ENV=development node_modules/node-dev/bin/node-dev server.coffee
+```
 
 ## Thrift
 

--- a/make/node.mk
+++ b/make/node.mk
@@ -1,0 +1,12 @@
+# This is the default Clever Node Makefile.
+# Please do not alter this file directly.
+NODE_MK_VERSION := 0.1.0
+
+# This block checks and confirms that the proper node version is installed.
+# arg1: node version. e.g. v6
+define node-version-check
+@if [[ `node -v` != $(1)* ]]; then \
+	@echo "", \
+	$(error "Node $(1) is required, use nvm to install / use node it"))
+fi
+endef


### PR DESCRIPTION
**Context**
We currently do a version check in the server file which is a little brittle and harder to scale across repos. Also it doesn't perform the check for other targets (notably tests) which then might fail with error messages that are not descriptive.

**Changes**
This PR adds a `node.mk` makefile with a function that checks the node version. Borrows from the [golang version check](https://github.com/Clever/dev-handbook/blob/bad3fcd493060c1a878c1ae2af7e3e452eb1b78f/make/golang.mk#L10-L16) and the one in [schools dashboard](https://github.com/Clever/schools-dashboard/blob/7f4984fd40624a958409b5ef3a9f8b00641692ad/Makefile#L64-L68)

Also adds example usage to the README.

**Tested**
Verified that the example makefile correctly does version checks for the `run` target.