### PR TITLE
Fixes node version check to only use makefile functions

### DIFF
--- a/make/node.mk
+++ b/make/node.mk
@@ -1,12 +1,12 @@
 # This is the default Clever Node Makefile.
 # Please do not alter this file directly.
-NODE_MK_VERSION := 0.1.0
+NODE_MK_VERSION := 0.1.1
 
 # This block checks and confirms that the proper node version is installed.
 # arg1: node version. e.g. v6
 define node-version-check
-@if [[ `node -v` != $(1)* ]]; then \
+_ := $(if \
+	$(shell node -v | grep $(1)), \
 	@echo "", \
 	$(error "Node $(1) is required, use nvm to install / use node it"))
-fi
 endef


### PR DESCRIPTION
The previous function did not work because it mixed up bash functions (the conditional) and makefile functions (error). This PR changes the implementation to use pure makefile functions, similar to the golang makefile.

Tested:
Verified that adding
```makefile
NODE_VERSION := "v6"

$(eval $(call node-version-check,$(NODE_VERSION)))
```
causes the test to return an error when versions 0 or 5 are used, but pass when version 6 is used.