### PR TITLE
Change coffee file count function to use /tmp instead of $TMPDIR

### DIFF
--- a/make/node.mk
+++ b/make/node.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Node Makefile.
 # Please do not alter this file directly.
-NODE_MK_VERSION := 0.2.0
+NODE_MK_VERSION := 0.2.1
 
 # This block checks and confirms that the proper node version is installed.
 # arg1: node version. e.g. v6
@@ -16,14 +16,14 @@ endef
 # arg1: number of coffeescript files. e.g. 10
 define node-coffeescript-file-count-check
 @echo -e "\nChecking count of coffeescript files"
-@git ls-files '*.coffee' | wc -l | tr -d ' ' > $(TMPDIR)/node-coffee-file-count
-@if [ "`cat $(TMPDIR)/node-coffee-file-count`" -eq "$(1)" ]; then \
+@git ls-files '*.coffee' | wc -l | tr -d ' ' > /tmp/node-coffee-file-count
+@if [ "`cat /tmp/node-coffee-file-count`" -eq "$(1)" ]; then \
 	echo -e "\033[0;32m✓ No change in file count.\033[0m\n"; \
-elif [ "`cat $(TMPDIR)/node-coffee-file-count`" -gt "$(1)" ]; then \
+elif [ "`cat /tmp/node-coffee-file-count`" -gt "$(1)" ]; then \
 	echo -e "\033[0;31m✖ Found new coffeescript file(s). All new modules should be written in ES6.\033[0m\n"; \
 	exit 1; \
 else \
-	echo -e "\033[0;31m✖ Congrats! You have reduced the file count to `cat $(TMPDIR)/node-coffee-file-count`. Please lower the expected count in the Makefile.\033[0m\n"; \
+	echo -e "\033[0;31m✖ Congrats! You have reduced the file count to `cat /tmp/node-coffee-file-count`. Please lower the expected count in the Makefile.\033[0m\n"; \
 	exit 1; \
 fi
 endef


### PR DESCRIPTION
`$TMPDIR` is set on OS X but not in the VM (Ubuntu), apparently which caused errors like
```
Checking count of coffeescript files
/bin/bash: /node-coffee-file-count: Permission denied
make: *** [coffee-filecount-check] Error 1
```

Replaces `$TMPDIR` with `/tmp` going with the infra philosophy of only supporting the vm setup.

Tested by copying it to another repo and making sure the function still works