### PR TITLE
make: add self-update functionality

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Golang Makefile.
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.1.0
+GOLANG_MK_VERSION := 0.1.1
 
 SHELL := /bin/bash
 .PHONY: golang-godep-vendor golang-test-deps $(GODEP)
@@ -131,3 +131,8 @@ $(call golang-lint-strict,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
 endef
+
+# golang-update-makefile downloads latest version of golang.mk
+golang-update-makefile:
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/golang.mk -O /tmp/golang.mk 2>/dev/null
+	@if ! grep -q $(GOLANG_MK_VERSION) /tmp/golang.mk; then cp /tmp/golang.mk golang.mk && echo "golang.mk updated"; else echo "golang.mk is up-to-date"; fi

--- a/make/node.mk
+++ b/make/node.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Node Makefile.
 # Please do not alter this file directly.
-NODE_MK_VERSION := 0.2.1
+NODE_MK_VERSION := 0.2.2
 
 # This block checks and confirms that the proper node version is installed.
 # arg1: node version. e.g. v6
@@ -27,3 +27,8 @@ else \
 	exit 1; \
 fi
 endef
+
+# node-update-makefile downloads latest version of node.mk
+node-update-makefile:
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/node.mk -O /tmp/node.mk 2>/dev/null
+	@if ! grep -q $(NODE_MK_VERSION) /tmp/node.mk; then cp /tmp/node.mk node.mk && echo "node.mk updated"; else echo "node.mk is up-to-date"; fi

--- a/make/swagger.mk
+++ b/make/swagger.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Swagger Makefile.
 # Please do not alter this file directly.
-SWAGGER_MK_VERSION := 0.4.4
+SWAGGER_MK_VERSION := 0.4.5
 
 SHELL := /bin/bash
 
@@ -52,3 +52,7 @@ docker run -v `pwd`:/src -i -t $(SWAGGER_CODEGEN_CLI_IMAGE) \
   --additional-properties "usePromises=true,useTracing=true,projectName=$(2),projectVersion=$(3),moduleName=$(4)"
 sudo chown -R $(USER):$(GROUP) gen-js
 endef
+
+swagger-update-makefile:
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/swagger.mk -O /tmp/swagger.mk 2>/dev/null
+	@if ! grep -q $(SWAGGER_MK_VERSION) /tmp/swagger.mk; then cp /tmp/swagger.mk swagger.mk && echo "swagger.mk updated"; else echo "swagger.mk is up-to-date"; fi

--- a/make/thrift.mk
+++ b/make/thrift.mk
@@ -1,5 +1,6 @@
 # This is the default Clever Thrift Makefile.
 # Please do not alter this file directly.
+THRIFT_MK_VERSION := 0.1.0
 
 # thrift-all generates client code for Python, Golang and Nodejs.
 define thrift-all
@@ -46,3 +47,8 @@ thrift-bump-minor:
 thrift-bump-major:
 	$(call thrift-bump-version, major)
 endef
+
+# thrift-update-makefile downloads latest version of thrift.mk
+thrift-update-makefile:
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/thrift.mk -O /tmp/thrift.mk 2>/dev/null
+	@if ! grep -q $(THRIFT_MK_VERSION) /tmp/thrift.mk; then cp /tmp/thrift.mk thrift.mk && echo "thrift.mk updated"; else echo "thrift.mk is up-to-date"; fi


### PR DESCRIPTION
Running a command like

```bash
make swagger-update-makefile
``` 

now overwrites your local `swagger.mk` with the latest version from the dev-handbook.

also supported

```bash
make thrift-update-makefile
make golang-update-makefile
make node-update-makefile
```