### PR TITLE
make/golang.mk - use only first dir in GOPATH

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -1,9 +1,12 @@
 # This is the default Clever Golang Makefile.
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.1.2
+GOLANG_MK_VERSION := 0.1.3
 
 SHELL := /bin/bash
 .PHONY: golang-godep-vendor golang-test-deps $(GODEP)
+
+# if the gopath includes several directories, use only the first
+GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
 
 # This block checks and confirms that the proper Go toolchain version is installed.
 # arg1: golang version


### PR DESCRIPTION
In CircleCI, the default GOPATH has multiple dirs:

    GOPATH=dir1;dir2;...

We only want to use the first one of these.
The rest of `golang.mk` already expects a $(GOPATH) with only one
directory in it.