### PR TITLE
Add mockgen dependency to wag-generate-deps

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.3.0
+WAG_MK_VERSION := 0.3.1
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
@@ -25,8 +25,12 @@ jsdoc2md:
 	hash npm 2>/dev/null || (echo "Could not run npm, please install node" && false)
 	hash jsdoc2md 2>/dev/null || npm install -g jsdoc-to-markdown@^2.0.0
 
+MOCKGEN := $(GOPATH)/bin/mockgen
+$(MOCKGEN):
+	go get -u github.com/golang/mock/mockgen
+
 # wag-generate-deps installs all dependencies needed for wag generate.
-wag-generate-deps: bin/wag jsdoc2md
+wag-generate-deps: bin/wag jsdoc2md $(MOCKGEN)
 
 # wag-generate is a target for generating code from a swagger.yml using wag
 # arg1: path to swagger.yml


### PR DESCRIPTION
Without this binary on my system, I get the following error:
```
go generate github.com/Clever/app-service/gen-go/server github.com/Clever/app-service/gen-go/client github.com/Clever/app-service/gen-go/models
gen-go/server/interface.go:9: running "/Users/abhinavgarg/go/bin/mockgen": fork/exec /Users/abhinavgarg/go/bin/mockgen: no such file or directory
gen-go/client/interface.go:9: running "/Users/abhinavgarg/go/bin/mockgen": fork/exec /Users/abhinavgarg/go/bin/mockgen: no such file or directory
```

Tested by removing the binary and re-running `make generate` after these changes.