### PR TITLE
Update latest configurations for node projects

### DIFF
--- a/javascript/.eslintrc.yml
+++ b/javascript/.eslintrc.yml
@@ -6,3 +6,28 @@ plugins:
   - "react"
 env:
   mocha: true
+  es6: true
+rules:
+  max-len: ["error", 120, 2, { # 120 max len, 2 tab width
+    ignoreUrls: true,
+    ignoreComments: false
+  }]
+  quotes: ["error", "double", "avoid-escape"]
+  no-shadow: ["error", { allow: ["err"] }]
+  eqeqeq: ["error", "always", {"null": "ignore"}]
+  space-before-keywords: 0 # deprecated, replaced with 'keyword-spacing'
+  space-after-keywords: 0 # deprecated, replaced with 'keyword-spacing'
+  space-return-throw-case: 0 # deprecated, replaced with 'keyword-spacing'
+  no-empty-label: 0 # deprecated, replaced with 'no-labels'
+  keyword-spacing: [2, {
+    before: true,
+    after: true,
+    overrides: {
+      return: { after: true },
+      throw: { after: true },
+      case: { after: true }
+    }
+  }]
+  no-labels: [2, { allowLoop: false, allowSwitch: false }]
+  no-unused-vars: ["error", { "argsIgnorePattern": "next" }]
+  no-param-reassign: 0 # TODO: Add back with exceptions when https://github.com/eslint/eslint/issues/6505 is resolved

--- a/javascript/.node-dev.json
+++ b/javascript/.node-dev.json
@@ -1,0 +1,6 @@
+
+{
+  "extensions": {
+    "ts": "ts-node/register"
+  }
+}

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": false,
+        "experimentalDecorators": true,
+        "lib": [
+            "es2017"
+        ],
+        "types": [
+            "node", "mocha"
+        ]
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/javascript/tslint.json
+++ b/javascript/tslint.json
@@ -2,7 +2,6 @@
   "rules": {
     "align": [
       true,
-      "parameters",
       "statements"
     ],
     "ban": false,
@@ -57,7 +56,7 @@
     "no-internal-module": true,
     "no-null-keyword": false,
     "no-require-imports": false,
-    "no-shadowed-variable": true,
+    "no-shadowed-variable": false,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,


### PR DESCRIPTION
We want to have a fixed place which contains canonical versions of all the configs needed for node projects. Right now we point to different repos, which means that documentation gets out of date once those repos don't have the latest version.

This PR uses OAuth as the source for `.eslintrc.yml`, `tsconfig.json`, and `tslint.json`. It grabs the `.node-dev.json` from https://clever.atlassian.net/wiki/display/ENG/ES6+at+Clever