### PR TITLE
make/golang.mk: Add golang-build command

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.3.0
+GOLANG_MK_VERSION := 0.3.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -160,10 +160,10 @@ endef
 define golang-build
 @echo "BUILDING..."
 @if [ -z "$$CI" ]; then \
-	go build -o build/$(2) $(1); \
+	go build -o bin/$(2) $(1); \
 else \
 	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(2) $(1); \
+	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
 fi;
 endef
 

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -154,6 +154,19 @@ $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
 endef
 
+# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# arg1: pkg path
+# arg2: executable name
+define golang-build
+@echo "BUILDING..."
+@if [ -z "$$CI" ]; then \
+	go build -o build/$(2) $(1); \
+else \
+	echo "-> Building CGO binary"; \
+	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(2) $(1); \
+fi;
+endef
+
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:
 	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/golang.mk -O /tmp/golang.mk 2>/dev/null


### PR DESCRIPTION
This helps simplify what users write in their makefile. It also improves build speed locally.

### Configuration

By adding this to their `Makefile`:

```
build:
  $(call golang-build,$(PKG),$(EXECUTABLE))
```

it handles doing the right build for local (regular `go build`) vs remote (`go build ` with CGO, ready for Alpine linux).

### Speed

A big reason to do this is for faster iteration locally. Anecdotally, I see builds that take a few seconds (~1-3 seconds) without CGO taking 10x as long (~10-20 seconds) with CGO.

### Example

https://github.com/Clever/dapple/compare/update-makefile