### PR TITLE
Golang mk update dep

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -40,12 +40,17 @@ DEP_VERSION = v0.4.1
 DEP_INSTALLED := $(shell [[ -e "bin/dep" ]] && bin/dep version | grep version | grep -v go | cut -d: -f2 | tr -d '[:space:]')
 # Dep is a tool used to manage Golang dependencies. It is the offical vendoring experiment, but
 # not yet the official tool for Golang.
+ifeq ($(DEP_VERSION),$(DEP_INSTALLED))
+bin/dep: # nothing to do, dep is already up-to-date
+else
+CACHED_DEP = /tmp/dep-$(DEP_VERSION)
 bin/dep: golang-ensure-curl-installed
+	@echo "Updating dep..."
 	@mkdir -p bin
-	@[[ "$(DEP_VERSION)" != "$(DEP_INSTALLED)" ]] && \
-		echo "Updating dep..." && \
-		curl -o bin/dep -sL https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(SYSTEM)-amd64 && \
-		chmod +x bin/dep || true
+	@if [ ! -f $(CACHED_DEP) ]; then curl -o $(CACHED_DEP) -sL https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(SYSTEM)-amd64; fi;
+	@cp $(CACHED_DEP) bin/dep
+	@chmod +x bin/dep || true
+endif
 
 golang-dep-vendor-deps: bin/dep
 

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.3.2
+GOLANG_MK_VERSION := 0.3.3
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -36,7 +36,7 @@ $(FGT):
 golang-ensure-curl-installed:
 	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
 
-DEP_VERSION = v0.3.2
+DEP_VERSION = v0.4.1
 DEP_INSTALLED := $(shell [[ -e "bin/dep" ]] && bin/dep version | grep version | grep -v go | cut -d: -f2 | tr -d '[:space:]')
 # Dep is a tool used to manage Golang dependencies. It is the offical vendoring experiment, but
 # not yet the official tool for Golang.


### PR DESCRIPTION
- bump dep from v0.3.2 => v0.4.1 0c6ac9e
- golang.mk: cache downloaded `dep` binary in /tmp/  abe9da9

You've already got `dep-v<x>` installed in another project... why
download it again?

From local testing, copying cached version of dep reduces the time to
run `make bin/dep` from ~10s to ~2s