### PR TITLE
WIP: automate nvm use

### DIFF
--- a/make/node.mk
+++ b/make/node.mk
@@ -7,10 +7,7 @@ SHELL := /bin/bash
 # This block checks and confirms that the proper node version is installed.
 # arg1: node version. e.g. v6
 define node-version-check
-_ := $(if \
-	$(shell node -v | grep $(1)), \
-	@echo "", \
-	$(error "Node $(1) is required, use nvm to install / use it"))
+_ := $(shell nvm use $(1))
 endef
 
 # This block checks and confirms the number of coffeescript files in the repo. The function must be


### PR DESCRIPTION
WIP

Here's how I was trying it:

```
$ cd <some project with node.mk>
$ cp $CODE_HOME/dev-handbook/make/node.mk . && make build
overwrite ./node.mk? (y/n [n]) y
/bin/bash: nvm: command not found
No build steps configured
```

My problem was that I'd only installed nvm within `zsh`, I think. 

Ideas:
- set the shell in node.mk to the user's shell? (might fail if they use `fish` shell or something)
- teach users to set up `nvm` so that the function is defined in both their bash shell too, even if that's not their primary shell (or do this setup automatically inside of `node.mk`)
