### PR TITLE
wag.mk: s/types/errors

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -37,7 +37,7 @@ wag-generate-deps: bin/wag jsdoc2md $(MOCKGEN)
 # arg2: pkg path
 define wag-generate
 bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1)
-(cd ./gen-js && jsdoc2md index.js types.js > ./README.md)
+(cd ./gen-js && jsdoc2md index.js errors.js > ./README.md)
 go generate $(2)/gen-go/server $(2)/gen-go/client $(2)/gen-go/models
 endef
 


### PR DESCRIPTION
clarify file name -- it defines some error types..

Since we're adding adding support for Typescript typings I thought this was more clear

https://github.com/Clever/wag/pull/184/