### PR TITLE
Remove shady link

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -13,4 +13,4 @@ Development tools we use, and resources to learn more about them.
 
 ### JavaScript
 
-- [Five Patterns to Help You Tame Asynchronous JavaScript](http://tech.pro/blog/1402/five-patterns-to-help-you-tame-asynchronous-javascript)
+- [Five Patterns to Help You Tame Asynchronous JavaScript](http://sking7.github.io/articles/389411742.html)


### PR DESCRIPTION
This link 
`http://tech.pro/blog/1402/five-patterns-to-help-you-tame-asynchronous-javascript`

for the five patterns of async js redirects to a shady website. I've replaced it with what I believe is the original article.

I can remove it all together if you think that would be a better idea? 