### PR TITLE
Add await promise rule

### DIFF
--- a/javascript/tslint.json
+++ b/javascript/tslint.json
@@ -5,6 +5,7 @@
     "tslint-react-a11y"
   ],
   "rules": {
+    "await-promise": true,
     "ban": false,
     "class-name": true,
     "comment-format": [

--- a/make/node.mk
+++ b/make/node.mk
@@ -100,7 +100,7 @@ node-prettier-lint:
 .PHONY: node-tslint
 node-tslint:
 	@echo "Running tslint..."
-	@./node_modules/.bin/tslint -t verbose $(NODE_ALL_FILES)
+	@./node_modules/.bin/tslint --project tsconfig.json -t verbose $(NODE_ALL_FILES)
 
 .PHONY: node-prettier-format
 node-prettier-format:
@@ -110,4 +110,4 @@ node-prettier-format:
 .PHONY: node-tslint-fix
 node-tslint-fix:
 	@echo "Running tslint fix..."
-	@./node_modules/.bin/tslint --fix -t verbose $(NODE_ALL_FILES)
+	@./node_modules/.bin/tslint --fix --project tsconfig.json -t verbose $(NODE_ALL_FILES)


### PR DESCRIPTION
Adds the `await-promise` rule to the tslint.json file. Also updates the tslint runner in the Makefile to specify the `--project` flag (without which `await-promise` will not work)