### PR TITLE
Address bug in lambda-build-node command

### DIFF
--- a/make/lambda.mk
+++ b/make/lambda.mk
@@ -25,7 +25,7 @@ define lambda-build-node
 @npm install --quiet --production
 @cp -r node_modules/ bin/node_modules/
 @echo 'Creating zip file...'
-@(cd bin/ && zip -qr $(2).zip index.js node_modules/)
+@(cd bin/ && zip -qr $(2).zip *)
 @echo 'Restoring dev dependencies...'
 @npm install --quiet
 endef


### PR DESCRIPTION
The compilation process builds not only an `index.js file` but also JS files for TS files imported by `index.ts`. This update makes sure that we include those files in our zip file for AWS.