### PR TITLE
[SEC-756] create sql.mk for golang sql

### DIFF
--- a/make/README.md
+++ b/make/README.md
@@ -90,3 +90,7 @@ swagger-generate: validate swagger-generate-go-server-deps swagger-generate-java
 	$(call swagger-generate-javascript-client,$(SWAGGER_CONFIG),$(SWAGGER_CLIENT_NPM_PACKAGE),$(VERSION))
 	$(call swagger-generate-go-client,$(SWAGGER_CONFIG))
 ```
+
+# SQL
+
+- install and run safesql (a Golang SQL injection checking tool)

--- a/make/README.md
+++ b/make/README.md
@@ -94,3 +94,5 @@ swagger-generate: validate swagger-generate-go-server-deps swagger-generate-java
 # SQL
 
 - install and run safesql (a Golang SQL injection checking tool)
+
+Safesql provides an option to ignore a line or query. If you plan to ignore a safesql failure, discuss it with security before release. 

--- a/make/sql.mk
+++ b/make/sql.mk
@@ -1,0 +1,44 @@
+# This is the default Clever SQL Makefile.
+# It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
+# Please do not alter this file directly.
+SQL_MK_VERSION := 0.0.1
+
+# USAGE:
+# - safesql
+#   In your project's Makefile, run safesql as part of the `test` command. Example:
+# 	```
+# 	test: $(PKGS) safesql
+# 	```
+# 	In test output, you will see "SCANNING SQL" and then the output of the safesql tool.
+
+
+SHELL := /bin/bash
+.PHONY: run-safesql run-safesql-deps
+
+# if the gopath includes several directories, use only the first
+GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
+
+# safesql is a static analysis tool for Go that checks for vulnerability to SQL injections.
+safesql: run-safesql-deps
+	$(call run-safesql,$(PKG))
+
+# to install and runs safesql
+SAFESQL := $(GOPATH)/bin/safesql
+$(SAFESQL):
+	go get github.com/stripe/safesql
+
+# run-safesql-deps requires the SAFESQL tool
+run-safesql-deps: $(SAFESQL)
+
+# run-safesql runs safesql on the pkg.
+# arg1: pkg path
+define run-safesql
+echo "SCANNING SQL $(1)..."
+$(GOPATH)/bin/safesql $(1)
+endef
+
+# sql-update-makefile downloads latest version of sql.mk
+sql-update-makefile:
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/sql.mk -O /tmp/sql.mk 2>/dev/null
+	@if ! grep -q $(SQL_MK_VERSION) /tmp/sql.mk; then cp /tmp/sql.mk sql.mk && echo "sql.mk updated"; else echo "sql.mk is up-to-date"; fi
+

--- a/make/sql.mk
+++ b/make/sql.mk
@@ -1,7 +1,7 @@
 # This is the default Clever SQL Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-SQL_MK_VERSION := 0.0.1
+SQL_MK_VERSION := 0.0.2
 
 # USAGE:
 # - safesql
@@ -22,15 +22,16 @@ GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
 safesql: run-safesql-deps
 	$(call run-safesql,$(PKG))
 
-# to install and runs safesql
+# safesql executable 
 SAFESQL := $(GOPATH)/bin/safesql
+# install safesql
 $(SAFESQL):
 	go get github.com/stripe/safesql
 
-# run-safesql-deps requires the SAFESQL tool
+# run-safesql-deps requires the safesql tool
 run-safesql-deps: $(SAFESQL)
 
-# run-safesql runs safesql on the pkg.
+# run-safesql runs safesql on the pkg
 # arg1: pkg path
 define run-safesql
 echo "SCANNING SQL $(1)..."


### PR DESCRIPTION
[SEC-756](): automate checks for sql injection  

Adds a sql.mk file that enables a `safesql` command that golang repos can add to tests.

Working in [library-analytics-service](https://github.com/Clever/library-analytics-service/pull/9) (check succeeds) and [teacher-authorizations](https://github.com/Clever/teacher-authorizations/pull/99) (check fails).