### PR TITLE
[SEC-756] remove use of PKG in sql.mk and simplify

### DIFF
--- a/make/sql.mk
+++ b/make/sql.mk
@@ -1,40 +1,32 @@
 # This is the default Clever SQL Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-SQL_MK_VERSION := 0.0.2
+SQL_MK_VERSION := 0.0.3
 
 # USAGE:
 # - safesql
-#   In your project's Makefile, run safesql as part of the `test` command. Example:
+#   safesql is a static analysis tool for Go that checks for vulnerability to SQL injections.
+#   In your project's Makefile, call run-safesql. Example:
 # 	```
-# 	test: $(PKGS) safesql
+# 	PKG = github.com/Clever/$(APP_NAME)
+#
+# 	safesql:
+# 		$(call run-safesql,$(PKG))
 # 	```
-# 	In test output, you will see "SCANNING SQL" and then the output of the safesql tool.
-
+# 	Running make safesql will show "SCANNING SQL" and then the output of the safesql tool.
 
 SHELL := /bin/bash
-.PHONY: run-safesql run-safesql-deps
+.PHONY: run-safesql sql-update-makefile
 
 # if the gopath includes several directories, use only the first
 GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
 
-# safesql is a static analysis tool for Go that checks for vulnerability to SQL injections.
-safesql: run-safesql-deps
-	$(call run-safesql,$(PKG))
-
-# safesql executable 
-SAFESQL := $(GOPATH)/bin/safesql
-# install safesql
-$(SAFESQL):
-	go get github.com/stripe/safesql
-
-# run-safesql-deps requires the safesql tool
-run-safesql-deps: $(SAFESQL)
-
 # run-safesql runs safesql on the pkg
 # arg1: pkg path
 define run-safesql
-echo "SCANNING SQL $(1)..."
+@go get github.com/stripe/safesql
+@echo ""
+@echo "SCANNING SQL $(1)..."
 $(GOPATH)/bin/safesql $(1)
 endef
 
@@ -42,4 +34,3 @@ endef
 sql-update-makefile:
 	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/sql.mk -O /tmp/sql.mk 2>/dev/null
 	@if ! grep -q $(SQL_MK_VERSION) /tmp/sql.mk; then cp /tmp/sql.mk sql.mk && echo "sql.mk updated"; else echo "sql.mk is up-to-date"; fi
-


### PR DESCRIPTION
[SEC-756](https://clever.atlassian.net/browse/SEC-756) (automate checks for sql injection)  

The previous version of sql.mk (from #132) uses a `PKG` variable that is not defined within sql.mk.  This PR removes the use of `PKG` from sql.mk so that Makefiles can continue to set it up and pass it as an argument to the `run-safesql` command.  

This PR also simplifies the code to install and run safesql, combining both the `go get` step and the actual execution into `run-safesql`.   

Tested by adding this version to [teacher-authorizations](https://circleci.com/gh/Clever/teacher-authorizations/456) (check correctly fails).