### PR TITLE
update jsdoc-to-markdown version

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -23,7 +23,7 @@ bin/wag: ensure-wag-version-set
 
 jsdoc2md:
 	hash npm 2>/dev/null || (echo "Could not run npm, please install node" && false)
-	test -f ./node_modules/.bin/jsdoc2md || npm install jsdoc-to-markdown@^2.0.0
+	test -f ./node_modules/.bin/jsdoc2md || npm install jsdoc-to-markdown@^4.0.0
 
 # wag-generate-deps installs all dependencies needed for wag generate.
 wag-generate-deps: bin/wag jsdoc2md

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.4.1
+WAG_MK_VERSION := 0.4.2
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)


### PR DESCRIPTION
## Link to JIRA

## Overview
this PR https://github.com/Clever/wag/pull/303 added a method that uses `async` jsdoc v2 does cannot parse async funcs. This PR bumps the version to 4.

## Testing

## Rollout
