### PR TITLE
Update JS formatting documentation

### DIFF
--- a/javascript/.prettierrc.json
+++ b/javascript/.prettierrc.json
@@ -1,12 +1,1 @@
-{
-  "overrides": [
-    {
-      "files": "*",
-      "options": {
-        "trailingComma": "all",
-        "bracketSpacing": true,
-        "printWidth": 100
-      }
-    }
-  ]
-}
+"@clever/prettier-config"

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -9,7 +9,7 @@ See the [editor setup guide](https://clever.atlassian.net/wiki/display/ENG/How+t
 We use [tslint](https://github.com/palantir/tslint) for linting and automatic formatting of JavaScript, TypeScript, JSX, and TSX files.
 
 
-We use [prettier](https://github.com/prettier/prettier) to automatically format JavaScript, TypeScript, JSX, and TSX files. Our code conforms to Prettier's preferred styles.
+We use [prettier](https://github.com/prettier/prettier) to automatically format JavaScript, TypeScript, JSX, TSX, and Less files. Our code mostly conforms to Prettier's preferred styles, with a couple of tweaks.
 
 
 ### Set Up Code Linting and Formatting
@@ -28,9 +28,9 @@ This section describes how to convert a repo with eslint and tslint to use prett
 	- `npm install --save-dev tslint-eslint-rules` to get additional tslint rule definitions that replace some from eslint
 	- `npm install --save-dev tslint-react` for additional react tslint rule definitions
 
-3. Install and configure prettier.
+3. Install prettier and [Clever's shared configuration](https://github.com/Clever/prettier-config).
  	- Add the `.prettierrc.json` prettier config file from this dev-handbook directory.
- 	- `npm install --save-dev prettier`
+ 	- `npm install --save-dev --exact prettier @clever/prettier-config`
 
 4. In the Makefile, define a make target to run prettier autoformatting. We like `format`:
 
@@ -38,25 +38,39 @@ This section describes how to convert a repo with eslint and tslint to use prett
 
 	# remember to define TS_FILES, JSX_FILES, etc as needed and
 	# pass them to format and lint commands
+	TS_FILES := $(shell find . -name "*.ts" -not -path "./node_modules/*")
+	FORMATTED_FILES := $(TS_FILES)
+	MODIFIED_FORMATTED_FILES := $(shell git diff --name-only master $(FORMATTED_FILES))
+	PRETTIER := ./node_modules/.bin/prettier
+
 	format:
-	 	./node_modules/.bin/prettier --write $(TS_FILES)
+		@echo "Formatting modified files..."
+		@$(PRETTIER) --write $(MODIFIED_FORMATTED_FILES)
+
+	format-all:
+		@echo "Formatting all files..."
+		@$(PRETTIER) --write $(FORMATTED_FILES)
+
+	format-check:
+		@echo "Running format check..."
+		@$(PRETTIER) --list-different $(FORMATTED_FILES) || \
+			(echo -e "❌ \033[0;31m Prettier found discrepancies in the above files. Run 'make format' to fix.\033[0m" && false)
 
 	```
 
-	> Note that the `--write` flag means prettier will make changes to files.
+	> Note that the `--write` flag means prettier will make changes to files. \
+	> The `--list-different` flag will only *list* files where the current format does not match prettier formatting.
 
 5.  In the Makefile, update the `lint` make target to include prettier linting:
 
 
 	```make
-	lint: ./node_modules/.bin/tslint -t verbose $(TS_FILES)
- 		./node_modules/.bin/prettier -l $(TS_FILES)
+	lint: format-check
+		./node_modules/.bin/tslint -t verbose $(TS_FILES)
  	```
 
- 	> The `-l` flag for prettier means prettier will only *list* files where the current format does not match prettier formatting.
-
 6. Update code based on new linting.
-	- run `make format`
+	- run `make format-all`
 	- run `make tslint`
 	- fix any remaining errors
 


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/node-37

## Overview
Now that Clever has a [shared config for prettier](https://github.com/Clever/prettier-config), let's reference that here and update the formatting documentation. I updated the `format` make target to only format updated files, and I ported over the `format-all` and format-check` commands to be consistent with most of our repos.

The documentation related to linting also needs updating, but I decided not to tackle that in this change.

## Testing

## Rollout
