### PR TITLE
wag.mk to pass correct flags to wag when using modules

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -32,10 +32,14 @@ wag-generate-deps: bin/wag jsdoc2md
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-/bin/sh -c 'if [ -f go.mod ]; \
-then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); \
-else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
-fi'
+bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1)
+(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
+endef
+
+# wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
+# arg1: path to swagger.yml
+define wag-generate-mod
+bin/wag -output-path gen-go -js-path ./gen-js -file $(1)
 (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
 endef
 

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -32,7 +32,7 @@ wag-generate-deps: bin/wag jsdoc2md
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-/bin/sh -c 'if [ -f go.smod ]; then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); fi'
+/bin/sh -c 'if [ -f go.mod ]; then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); fi'
 (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
 endef
 

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.4.2
+WAG_MK_VERSION := 0.4.3
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -32,7 +32,7 @@ wag-generate-deps: bin/wag jsdoc2md
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1)
+/bin/sh -c 'if [ -f go.smod ]; then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); fi'
 (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
 endef
 

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -32,7 +32,10 @@ wag-generate-deps: bin/wag jsdoc2md
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-/bin/sh -c 'if [ -f go.mod ]; then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); fi'
+/bin/sh -c 'if [ -f go.mod ]; \
+then bin/wag -output-path gen-go -js-path ./gen-js -file $(1); \
+else bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
+fi'
 (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
 endef
 


### PR DESCRIPTION
## Link to JIRA
[Link to JIRA](url)

## Overview
checks if the `go.mod` file is present. If so executes wag with the ` -output-path` flag. If not, executes wag with the `-go-package` flag

## Testing
tested command locally
testing on CI https://app.circleci.com/jobs/github/Clever/content-mapping-service/358

## Rollout
