### PR TITLE
func to bump golang repo with modules' major version

### DIFF
--- a/make/golang-v1.mk
+++ b/make/golang-v1.mk
@@ -155,7 +155,7 @@ endef
 define golang-bump-major-version
 # bump go.mod
 $(eval $@OLD_VERSION := $(shell cat swagger.yml | grep 'version:\s[0-9].[0-9].[0-9]' | sed 's/[:|[:alpha:]|[:space:]]//g' | cut -d. -f1 ||\ 
-cat VERSION.yml | sed 's/[:|[:alpha:]|[:space:]]//g' | cut -d. -f1))
+cat VERSION | sed 's/[:|[:alpha:]|[:space:]]//g' | cut -d. -f1))
 $(eval $@NEW_VERSION := $(shell echo $$(($($@OLD_VERSION)+1))))
 sed -i '' '1s/v$(1)/v$($@NEW_VERSION)/' go.mod 
 


### PR DESCRIPTION
## Link to JIRA


## Overview

* added func to  bump the module's major version in go.mod, VERSION, swagger.yml, and non-vendored Go files.
* called with:
`$(call golang-bump-major-version)`
* i should probably add some clearer logic around when VERSION vs swagger.yml is used
* if you know how to do this without using eval, pls tell

## Testing
locally

## Rollout
