### PR TITLE
lambda.mk: migrate to provided.al2 runtime

### DIFF
--- a/make/lambda.mk
+++ b/make/lambda.mk
@@ -1,7 +1,7 @@
 # This is the default Clever lambda Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-LAMBDA_MK_VERSION := 0.2.2
+LAMBDA_MK_VERSION := 0.2.3
 SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go
@@ -11,7 +11,11 @@ GOPATH ?= $(HOME)/go
 # arg2: executable name
 define lambda-build-go
 @GOOS=linux go build -o bin/$(2) $(1)
-@(cd bin && zip $(2).zip $(2))
+# provided.al2 requires executable to be named `boostrap`
+# During migration include both `bootstrap` and `$(2)` in the
+# zip file, and once everything is on al2, remove `$(2)`
+@cp bin/$(2) bin/bootstrap
+@(cd bin && zip $(2).zip $(2) bootstrap)
 endef
 
 # lambda-build-node: builds a lambda function written in Node


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-4358

## Overview
the provided.al2 runtime in lambda is the only runtime that supports
Go and lambda layers.

This runtime assumes that the executable is named `bootstrap`:
https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html

This PR changes our lambda build process to include the binary with
the name `bootstrap`. It preserves the old behavior for
backwards-compatability while catapult changes to deploy things with
the new runtime.

## Testing
I tested this by manually uploading a zip file (for `ingest` in `clever-dev`) and successfully launching and running it with the provided.al2 runtime.

## Rollout
- Microplane this, verify everything deploys ok with the large zip file
- Change catapult to use provided.al2 for Go lambdas
- Change lambda.mk to remove the unused binary from the zip files, microplane again.
