### PR TITLE
lambda.mk include kvconfig in node lambdas

### DIFF
--- a/make/lambda.mk
+++ b/make/lambda.mk
@@ -1,7 +1,7 @@
 # This is the default Clever lambda Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-LAMBDA_MK_VERSION := 0.2.3
+LAMBDA_MK_VERSION := 0.2.4
 SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go
@@ -27,6 +27,8 @@ define lambda-build-node
 @rm -r node_modules/
 @npm install --quiet --production
 @cp -r node_modules/ bin/node_modules/
+@echo 'Copying kvconfig.yml...'	
+@cp kvconfig.yml bin/kvconfig.yml
 @echo 'Creating zip file...'
 @(cd bin/ && zip -qr $(1).zip *)
 @echo 'Restoring dev dependencies...'


### PR DESCRIPTION
https://github.com/Clever/frontend-to-end-tester/commit/d5a695538bb1f11b876b0b69e5b6beffb0324b4b

We only have one node lambda so far, but this seems like something we'd want to do in all of them in the future. We could put it in the main Makefile instead of here, but this seems preferable

## Rollout
In theory all of the lambda.mk's should be updated, but in particular I'll just update frontend-to-end-tester