### PR TITLE
Update security policy re rate limiting

### DIFF
--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -6,6 +6,8 @@ Coordinated disclosure rules
 * Alert us as soon as possible. Let us know upon discovery of a potential security issue, and we’ll make every effort to quickly correct the issue.
 * Let us triage, discuss, then publish. Provide us with a reasonable amount of time to fix the issue, and discuss with us before publishing it elsewhere.
 * Please use demo accounts. Not following the account creation steps below will render your report ineligible for a bounty. This includes automated/scripted account creation.
+* Using automated scanners and testing tools to send large number of requests (more than 1000 per day per endpoint) against the endpoints in the products, without prior notice or alerting to security@clever.com could render your report ineligible for bounty and could inevitably prompt us to disallow you from our program. If you are reporting a vulnerability regarding rate limiting or denial of service, you should let us know about the email address, account name, account ID, or other identifier associated with your testing setup, so that we can filter and attribute those large number of requests to you.
+
 
 Bounty eligibility
 ------------------

--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -6,7 +6,11 @@ Coordinated disclosure rules
 * Alert us as soon as possible. Let us know upon discovery of a potential security issue, and we’ll make every effort to quickly correct the issue.
 * Let us triage, discuss, then publish. Provide us with a reasonable amount of time to fix the issue, and discuss with us before publishing it elsewhere.
 * Please use demo accounts. Not following the account creation steps below will render your report ineligible for a bounty. This includes automated/scripted account creation.
-* Using automated scanners and testing tools to send large number of requests (more than 1000 per day per endpoint) against the endpoints in the products, without prior notice or alerting to security@clever.com could render your report ineligible for bounty and could inevitably prompt us to disallow you from our program. If you are reporting a vulnerability regarding rate limiting or denial of service, you should let us know about the email address, account name, account ID, or other identifier associated with your testing setup, so that we can filter and attribute those large number of requests to you.
+* Using automated scanners and testing tools to send large number of requests (more than 1000 per day per endpoint) against the endpoints in the products, without prior notice or alerting to security@clever.com could render your report ineligible for bounty and could inevitably prompt us to disallow you from our program. If you are reporting a vulnerability regarding rate limiting or denial of service, you should let us know about the email address, account name, account ID, or other identifier associated with your testing setup, so that we can filter and attribute those large number of requests to you. 
+
+** You should include a custom HTTP header in all your traffic. For example:
+A header that includes your username: X-Bug-Bounty:HackerOne-<username>
+A header that includes a unique or identifiable flag X-Bug-Bounty:ID-<sha256-flag>
 
 
 Bounty eligibility


### PR DESCRIPTION
## Link to JIRA
[SECNG-499](https://clever.atlassian.net/browse/SECNG-499)

## Overview
Update security policy regarding rate limit based reports. Specifically, it adds call out to say rate limiting without prior notice to us could promp us to disallow the report from bounty and even ban from the program. See ticket for specific instances where this happened.

## Testing
👁️ 
## Rollout
Once approved, update the H1 policy!
