### PR TITLE
wag.mk: don't download wag or generate code in CI

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,16 +1,18 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.5.1
+WAG_MK_VERSION := 0.6.0
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
+ifndef CI
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
 WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
-
+endif
 .PHONY: wag-update-makefile ensure-wag-version-set wag-generate-deps
 
 # identify path to jsdoc2md which makes it a file target
 VPATH = node_modules/.bin
 
+ifndef CI
 ensure-wag-version-set:
 	@ if [[ "$(WAG_VERSION)" = "" ]]; then \
 		echo "WAG_VERSION not set in Makefile - Suggest setting 'WAG_VERSION := latest'"; \
@@ -31,6 +33,11 @@ jsdoc2md:
 
 # wag-generate-deps installs all dependencies needed for wag generate.
 wag-generate-deps: bin/wag jsdoc2md
+else
+ensure-wag-version-set:
+bin/wag:
+jsdoc2md:
+endif
 
 # wag-yaml-aliases generate code workaround to use YAML aliases in swagger.yml for modules repos
 # wag parses the file into go-yaml's MapSlice, which does not handle out of order aliases: https://github.com/go-yaml/yaml/issues/438
@@ -41,7 +48,7 @@ define wag-yaml-aliases
 	bin/wag -output-path gen-go -js-path ./gen-js -file /tmp/swagger.catapult.yml; \
 	(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
 else \
-	echo "skipping wag in Circle CI"; \
+	echo "skipping wag-yaml-aliases in CI"; \
 fi;
 endef
 
@@ -49,15 +56,23 @@ endef
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1)
-(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
+@if [ -z "$$CI" ]; then \
+    bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+	echo "skipping wag-generate in CI"; \
+fi;
 endef
 
 # wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
 # arg1: path to swagger.yml
 define wag-generate-mod
-bin/wag -output-path gen-go -js-path ./gen-js -file $(1)
-(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
+@if [ -z "$$CI" ]; then \
+    bin/wag -output-path gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+    echo "skipping wag-generate-mod in CI"; \
+fi;
 endef
 
 wag-update-makefile:


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-4688

## Overview
We shouldn't do this in CI since it means whatever is in Github is not necessarily what is running in prod. 

It also helps when testing out pre-release versions of wag

## Testing

## Rollout
