### PR TITLE
Have go lambdas compile to arm

### DIFF
--- a/make/lambda.mk
+++ b/make/lambda.mk
@@ -1,7 +1,7 @@
 # This is the default Clever lambda Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-LAMBDA_MK_VERSION := 0.2.4
+LAMBDA_MK_VERSION := 0.3.0
 SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go

--- a/make/lambda.mk
+++ b/make/lambda.mk
@@ -6,11 +6,11 @@ SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go
 
-# lambda-build-go: builds a lambda function written in Go
+# lambda-build-go: builds a lambda function written in Go to run on Arm64 architecture
 # arg1: pkg path
 # arg2: executable name
 define lambda-build-go
-@GOOS=linux go build -o bin/$(2) $(1)
+@GOOS=linux GOARCH=arm64 go build -o bin/$(2) $(1)
 # provided.al2 requires executable to be named `boostrap`
 # During migration include both `bootstrap` and `$(2)` in the
 # zip file, and once everything is on al2, remove `$(2)`


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-4796

## Overview
This PR edits the lambda makefile to compile go lambdas to run on the arm architecture, to allow the lambdas to run on AWS Graviton. All go lambdas _should_ be able to run on arm. 

## Testing

I only plan to merge this after I have tested with a few lambdas in prod.

## Rollout
