### PR TITLE
Update to pull in pre-release versions as well

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
-WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
+WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases | grep tag_name | head -1 | cut -d\" -f4)
 endif
 .PHONY: wag-update-makefile ensure-wag-version-set wag-generate-deps
 
@@ -22,16 +22,18 @@ ensure-wag-version-set:
 bin/wag: ensure-wag-version-set
 	@mkdir -p bin
 	$(eval WAG_VERSION := $(if $(filter latest,$(WAG_VERSION)),$(WAG_LATEST),$(WAG_VERSION)))
+	@echo $(WAG_VERSION), $(WAG_INSTALLED)
 	@echo "Checking for wag updates..."
 	@echo "Using wag version $(WAG_INSTALLED)"
-	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && echo "Updating wag...to $(WAG_VERSION)"  && wget -P bin https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz
+	@if [[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]]; \
+		then \
+			echo "Updating wag...to $(WAG_VERSION)"  && wget -P bin https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
+		fi;
 	@if [ -a bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ] ; \
 		then \
 			tar xvf bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz -C bin;\
 			rm bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
 		fi;
-       
-	
 
 	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && touch swagger.yml || true
 jsdoc2md:


### PR DESCRIPTION

## Overview
There seems to have been some mismatch between the version of this file on master and what has been used for the initial wag v9 rollout. This updates the version to match what is used in the rollout, such as [here](https://github.com/Clever/district-config-service/blob/master/wag.mk#L6).

## Testing

## Rollout
