### PR TITLE
Infrang 5162

### DIFF
--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,6 +1,6 @@
 # This is the default Clever Wag Makefile.	
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.6.1
+WAG_MK_VERSION := 0.6.3
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -78,6 +78,8 @@ define wag-generate-mod
 @if [ -z "$$CI"]; then \
     bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
     (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,4 +1,6 @@
-WAG_MK_VERSION := 0.6.3
+# This is the default Clever Wag Makefile.	
+# Please do not alter this file directly.
+WAG_MK_VERSION := 0.6.1
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI
@@ -64,6 +66,9 @@ endef
 # arg2: pkg path
 define wag-generate
 @if [ -z "$$CI" ]; then \
+    bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
 	echo "skipping wag-generate in CI"; \
 fi;
 endef
@@ -71,7 +76,9 @@ endef
 # wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
 # arg1: path to swagger.yml
 define wag-generate-mod
-@if [ -z "$$CI" ]; then \
+@if [ -z "$$CI"]; then \
+    bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,11 +1,9 @@
-# This is the default Clever Wag Makefile.
-# Please do not alter this file directly.
 WAG_MK_VERSION := 0.6.1
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
-WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
+WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases | grep tag_name | head -1 | cut -d\" -f4)
 endif
 .PHONY: wag-update-makefile ensure-wag-version-set wag-generate-deps
 
@@ -22,16 +20,18 @@ ensure-wag-version-set:
 bin/wag: ensure-wag-version-set
 	@mkdir -p bin
 	$(eval WAG_VERSION := $(if $(filter latest,$(WAG_VERSION)),$(WAG_LATEST),$(WAG_VERSION)))
+	@echo $(WAG_VERSION), $(WAG_INSTALLED)
 	@echo "Checking for wag updates..."
 	@echo "Using wag version $(WAG_INSTALLED)"
-	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && echo "Updating wag...to $(WAG_VERSION)"  && wget -P bin https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz
+	@if [[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]]; \
+		then \
+			echo "Updating wag...to $(WAG_VERSION)"  && wget -P bin https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
+		fi;
 	@if [ -a bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ] ; \
 		then \
 			tar xvf bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz -C bin;\
 			rm bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
 		fi;
-       
-	
 
 	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && touch swagger.yml || true
 jsdoc2md:

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,6 +1,6 @@
-# This is the default Clever Wag Makefile.	
+# This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.6.3
+WAG_MK_VERSION := 0.7.0
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI
@@ -75,7 +75,7 @@ endef
 # wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
 # arg1: path to swagger.yml
 define wag-generate-mod
-@if [ -z "$$CI"]; then \
+@if [ -z "$$CI" ]; then \
     bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
     (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
 else \

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -1,9 +1,9 @@
-WAG_MK_VERSION := 0.6.1
+WAG_MK_VERSION := 0.6.3
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 ifndef CI
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
-WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases | grep tag_name | head -1 | cut -d\" -f4)
+WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
 endif
 .PHONY: wag-update-makefile ensure-wag-version-set wag-generate-deps
 
@@ -64,9 +64,6 @@ endef
 # arg2: pkg path
 define wag-generate
 @if [ -z "$$CI" ]; then \
-    bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
-    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
-else \
 	echo "skipping wag-generate in CI"; \
 fi;
 endef
@@ -75,9 +72,6 @@ endef
 # arg1: path to swagger.yml
 define wag-generate-mod
 @if [ -z "$$CI" ]; then \
-    bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
-    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
-else \
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -52,7 +52,7 @@ endif
 define wag-yaml-aliases
 @if [ -z "$$CI" ]; then \
 	cat $(1) | python3 -c "import sys, yaml, json; y=yaml.load(sys.stdin.read(), yaml.Loader); print(yaml.dump(y))" > /tmp/swagger.catapult.yml; \
-	bin/wag -output-path gen-go -js-path ./gen-js -file /tmp/swagger.catapult.yml; \
+	bin/wag -output-path ./gen-go -js-path ./gen-js -file /tmp/swagger.catapult.yml; \
 	(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
 else \
 	echo "skipping wag-yaml-aliases in CI"; \
@@ -74,10 +74,9 @@ endef
 # wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
 # arg1: path to swagger.yml
 define wag-generate-mod
-@if [ -z "$$CI" ]; then \
-    bin/wag -output-path gen-go -js-path ./gen-js -file $(1); \
+@if [ -z "$$CI"]; then \
+    bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
     (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
-else \
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -79,7 +79,6 @@ define wag-generate-mod
     bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
     (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
 else \
-
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -22,7 +22,6 @@ ensure-wag-version-set:
 bin/wag: ensure-wag-version-set
 	@mkdir -p bin
 	$(eval WAG_VERSION := $(if $(filter latest,$(WAG_VERSION)),$(WAG_LATEST),$(WAG_VERSION)))
-	@echo $(WAG_VERSION), $(WAG_INSTALLED)
 	@echo "Checking for wag updates..."
 	@echo "Using wag version $(WAG_INSTALLED)"
 	@if [[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]]; \

--- a/make/wag.mk
+++ b/make/wag.mk
@@ -74,9 +74,10 @@ endef
 # wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
 # arg1: path to swagger.yml
 define wag-generate-mod
-@if [ -z "$$CI"]; then \
+@if [ -z "$$CI" ]; then \
     bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
     (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
     echo "skipping wag-generate-mod in CI"; \
 fi;
 endef


### PR DESCRIPTION
[Link to JIRA
](https://clever.atlassian.net/browse/INFRANG-5162)
## Overview
Changes to allow new output path setup for wagv9. 
Should now also pull in wag v9. 
Bumped two minor versions because the wagv9 beta used a custom wag.mk 0.6.2 that pulled in beta releases. 

## Testing

## Rollout
