### PR TITLE
Add language to explicit safe harbor and how to publish

### DIFF
--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -2,14 +2,18 @@ Clever is committed to working with security experts around the world to stay up
 
 Coordinated disclosure rules
 ----------------------------
-* Act in good faith. Do not leak, manipulate, or destroy any user data, or affect the availability of the site. Test against accounts you yourself own, or with explicit permission of the account holder. Do not attempt to access data that does not belong to your test account(s).
+* Act in good faith. Do not leak, manipulate, download or destroy any user data, or affect the availability of the site. Test against accounts you yourself own, or with explicit permission of the account holder. Do not attempt to access data that does not belong to your test account(s).
 * Alert us as soon as possible. Let us know upon discovery of a potential security issue, and we’ll make every effort to quickly correct the issue.
-* Let us triage, discuss, then publish. Provide us with a reasonable amount of time to fix the issue, and discuss with us before publishing it elsewhere.
+* Do not disclose to the public or anyone else the details of the vulnerability without discussing with us the vulnerability first. Provide us with a reasonable amount of time to fix the issue, any you may publish the vulnerability after we have confirmed we have remediated the issue. You can also publish if it has been nine (9) months since disclosure of the vulnerability to Clever's security team.
+* Do not disclose to anyone any propriety data revealed during your testing or the content of any data you accessed because of any vulnerabilities.
 * Please use demo accounts. Not following the account creation steps below will render your report ineligible for a bounty. This includes automated/scripted account creation.
+* Do not exploit any vulnerability beyond the minimal amount of testing required to prove that the vulnerability exists or to identify an indicator related to that vulnerability.
 * Using automated scanners and testing tools to send large number of requests (more than 1000 per day per endpoint) against the endpoints in the products, without prior notice or alerting to security@clever.com could render your report ineligible for bounty and could inevitably prompt us to disallow you from our program. If you are reporting a vulnerability regarding rate limiting or denial of service, you should let us know about the email address, account name, account ID, or other identifier associated with your testing setup, so that we can filter and attribute those large number of requests to you. 
 * You should include a custom HTTP header in all your traffic. For example:
   * A header that includes your username: X-Bug-Bounty: `HackerOne-Username`
   * A header that includes a unique or identifiable flag X-Bug-Bounty:`Unique-ID`
+
+If you make a good faith effort to conduct research and disclose vulnerabilities in accordance with our disclosure rules above, Clever will not recommend or pursue law enfgorcement or civil lawsuits related to such activities.
 
 Bounty eligibility
 ------------------


### PR DESCRIPTION
## Link to JIRA
[SECNG-1988](https://clever.atlassian.net/browse/SECNG-1988)

## Overview
Update the language to explicitly provide safe harbor for security research and criteria for publishing the vulnerability.

## Testing
No specific testing since this a documentation update.

## Rollout
💯 once approved

[SECNG-1988]: https://clever.atlassian.net/browse/SECNG-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ