### PR TITLE
fix(INFRANG-6623): Transition go install syntax to go get

### DIFF
--- a/make/golang-v1.mk
+++ b/make/golang-v1.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.3.1
+GOLANG_MK_VERSION := 1.3.2
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -39,7 +39,7 @@ endef
 # so we're defended against it breaking or changing in the future.
 FGT := $(GOPATH)/bin/fgt
 $(FGT):
-	go install -mod=readonly github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d
+	go get github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d
 
 golang-ensure-curl-installed:
 	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
@@ -51,7 +51,7 @@ golang-ensure-curl-installed:
 # Infra recommendation is to eventually move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
-	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
+	go get golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
 
 # golang-fmt-deps requires the FGT tool for checking output
 golang-fmt-deps: $(FGT)


### PR DESCRIPTION
## Link to JIRA
[[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-6623)](https://clever.atlassian.net/browse/INFRANG-6623)

## Overview

After the initial update, several builds are failing with messages similar to the following:
```
can't load package: package github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d: can only use path@version syntax with 'go get'
golang.mk:42: recipe for target '/go/bin/fgt' failed
make: *** [/go/bin/fgt] Error 1
```

This PR changes `go install` to `go get` to add back in support for installing specific versions of external packages we rely on.

## Testing
<details>
Ran `go get` commands to make sure we could install
</details>

## Rollout
