### PR TITLE
remove family portal from bug bounty scope

### DIFF
--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -67,7 +67,7 @@ The following guidelines suggest a base amount (impact x ease of exploitation) t
 Setting up accounts
 -------------------
 
-Clever's bug bounty has five products in scope:
+Clever's bug bounty has four products in scope:
 * Clever Portal (https://clever.com)
 * Schools Dashboard (https://schools.clever.com)
 * Application Dashboard (https://apps.clever.com)


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/SECNG-3281

## Overview
Family portal has been sunsetted, so should not be included in our bug bounty scope. 

## Testing
Not applicable

## Rollout
