### PR TITLE
docs(security): sharpen bug bounty reproduction guidance

### DIFF
--- a/security/bug-bounty.md
+++ b/security/bug-bounty.md
@@ -21,7 +21,12 @@ Vulnerabilities are eligible for the bug bounty program if they meet a minimum s
 
 * Represent an active threat to the confidentiality or integrity of Clever user data.
 * Be possible to mitigate through standard defensive measures.
-* Include a clear description along with steps to reproduce, including attachments such as screenshots or proof of concept code as necessary.
+* Include a clear description along with steps to reproduce. The fastest reports to triage:
+  * Name the endpoint(s) that were hit.
+  * Name the type of account(s) involved (e.g. district admin, teacher, student, app developer), and which one performed which action if more than one is involved.
+  * State the scope of the boundary crossed, e.g. within the same account, across accounts in the same school/district, across schools in one district, or across districts entirely. This has a big impact on severity, so being explicit here helps us triage faster and more accurately.
+  * Include the actual request that caused the impact, such as a `curl` command or raw HTTP request, rather than just a description of it - we can act fastest on something we can replay directly.
+  * Use screenshots (e.g. from Burp Suite), proof of concept code, or a proof of concept video as supporting evidence, not a substitute for the above.
 
 In general, the following would not meet the threshold for severity:
 


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## Link to Linear
[SECOC-624](https://linear.app/clever/issue/SECOC-624/flare-1938-formalize-hackerone-intake-to-emphasize-reproducibility)

## Overview
The bug bounty eligibility criteria previously asked for "steps to reproduce" without specifying what makes a report fast to triage. This adds explicit guidance asking reporters to:
- Name the endpoint(s) hit and the type of account(s) involved.
- State the scope of the boundary crossed (same account, cross-school, cross-district), since this drives severity.
- Prefer a replayable request (`curl`/raw HTTP) over a description of one.
- Use screenshots/PoC video as supporting evidence rather than a substitute for the above.

## Testing
Read-through of the updated `security/bug-bounty.md` for clarity and consistency with the rest of the doc; no code changes.

## Rollout
:100: (docs-only change, no runtime impact)